### PR TITLE
Discard any input from device after reset

### DIFF
--- a/telemetrix/telemetrix.py
+++ b/telemetrix/telemetrix.py
@@ -372,6 +372,10 @@ class Telemetrix(threading.Thread):
         for serial_port in serial_ports:
             self.serial_port = serial_port
 
+            # Since opening the port, there might be e.g., boot logs in the
+            # buffer. Clear them before proceeding.
+            self.serial_port.reset_input_buffer()
+
             self._get_arduino_id()
             if self.reported_arduino_id != self.arduino_instance_id:
                 continue


### PR DESCRIPTION
Hi, first, thank you for the project. It was quite easy to get started.

I run into a problem when using it with ESP32 Dev Modules. They output bootloader logs on the default serial line upon restart. On Windows, you get `Invalid Arduino ID: []`. Windows toggles DTR lines when you open a port, which restarts the module. The bootloader messages get into the input buffer, confusing the stream parser.

The bootloader messages can be disabled by flashing a custom bootloader or by keeping a given bootstrap pin low during reset; however, such a solution is not beginner-friendly.

I propose to discard the input buffer after opening the port. It should be safe as no meaningful communication should happen before we actually ask for the Arduino ID.