### PR TITLE
Bug fix where each stepper motor references the same info list

### DIFF
--- a/telemetrix/telemetrix.py
+++ b/telemetrix/telemetrix.py
@@ -259,7 +259,7 @@ class Telemetrix(threading.Thread):
         self.stepper_info_list = []
         # a list of dictionaries to hold stepper information
         for motor in range(self.max_number_of_steppers):
-            self.stepper_info_list.append(self.stepper_info)
+            self.stepper_info_list.append(self.stepper_info.copy())
 
         self.the_reporter_thread.start()
         self.the_data_receive_thread.start()


### PR DESCRIPTION
Hi, thanks for making this package, I've found it very useful! (I think) I've run into a bug with the `stepper_info_list`. TL;DR the `stepper_info_list` is not copied between motor instances, so when you call a method that requires a callback, it will always overwrite all other instances. As in, all stepper motor instances share the same info list.

This code snippet reproduces the issue that I see:

```python
from telemetrix import telemetrix
import time

board = telemetrix.Telemetrix()

def create_motor(pin1, pin2, enable):
    motor = board.set_pin_mode_stepper(pin1=pin1, pin2=pin2)
    board.stepper_set_enable_pin(motor, enable)
    board.stepper_set_3_pins_inverted(motor, enable=True)
    return motor

motorX = create_motor(2, 3, 8)
motorY = create_motor(4, 5, 8)

def current_position_callback_X(_):
    print('X')

def current_position_callback_Y(_):
    print('Y')

board.stepper_get_current_position(motorX, current_position_callback_X)
board.stepper_get_current_position(motorY, current_position_callback_Y)

time.sleep(1)
```

Which outputs:
```bash
Y
Y
```

Where the indented output (which is the result you get with the changes in this PR) is:
```bash
X
Y
```

I've created this PR assuming this is a bug, but maybe I'm using the library wrong. Please let me know if that's the case. Thanks again!