### PR TITLE
Introduce singleton port register

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ find = {}  # Scan the project directory with the default parameters
 
 [project]
 name = "telemetrix"
-version = "1.42"
+version = "1.43"
 authors = [
   { name="Alan Yorinks", email="MisterYsLab@gmail.com" },
 ]

--- a/telemetrix/telemetrix.py
+++ b/telemetrix/telemetrix.py
@@ -388,7 +388,6 @@ class Telemetrix(threading.Thread):
                 time.sleep(.2)
                 retries -= 1
             if self.reported_arduino_id != self.arduino_instance_id:
-                self.serial_port.close()
                 continue
             else:
                 print('Valid Arduino ID Found.')

--- a/telemetrix/telemetrix.py
+++ b/telemetrix/telemetrix.py
@@ -2215,13 +2215,16 @@ class Telemetrix(threading.Thread):
         :param data: digital message
 
         """
-        pin = data[0]
-        value = data[1]
+        try:
+            pin = data[0]
+            value = data[1]
 
-        time_stamp = time.time()
-        if self.digital_callbacks[pin]:
-            message = [PrivateConstants.DIGITAL_REPORT, pin, value, time_stamp]
-            self.digital_callbacks[pin](message)
+            time_stamp = time.time()
+            if self.digital_callbacks[pin]:
+                message = [PrivateConstants.DIGITAL_REPORT, pin, value, time_stamp]
+                self.digital_callbacks[pin](message)
+        except:
+            print('malformed message in _digital_message')
 
     def _firmware_message(self, data):
         """


### PR DESCRIPTION
### This PR will introduce a singleton port register.

In order to make auto com_port detection work with multiple instances the already correctly established connection need to be excluded for auto detection in following instances.
UPDATE:
After @MrYsLab idea i replaced the exlude_ports param with a singleton that keeps track of active ports automatically.

### Additionally:

- If _digital_message contains a malformed message the library won't break on `data[1]`
- if self.reported_arduino_id stays None in _find_arduino it will not be infinite anymore

### Multiple board setup:

```
board1 = telemetrix.Telemetrix(arduino_instance_id=1, arduino_wait=4)
board2 = telemetrix.Telemetrix(arduino_instance_id=2, arduino_wait=4)
board3 = telemetrix.Telemetrix(arduino_instance_id=3, arduino_wait=4)
```